### PR TITLE
Allow twig cache on development.services.yml

### DIFF
--- a/assets/development.services.yml
+++ b/assets/development.services.yml
@@ -7,7 +7,7 @@ parameters:
   twig.config:
     debug: true
     auto_reload: true
-    cache: false
+    cache: true
 services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory


### PR DESCRIPTION
We can safely enable twig caching mechanism since we also specify the `auto_reload` option.

Ref: https://www.drupal.org/docs/theming-drupal/twig-in-drupal/debugging-compiled-twig-templates#twig-auto-reload