### PR TITLE
Add localizations update on post-deploy script

### DIFF
--- a/assets/wodby.yml
+++ b/assets/wodby.yml
@@ -16,3 +16,8 @@ pipeline:
       drush sqlq "UPDATE users_field_data SET pass='#' WHERE mail LIKE '%@ramsalt.com';"
     directory: $WODBY_APP_DOCROOT
     only_if: '[ "$WODBY_ENVIRONMENT_TYPE" = "prod" ] && [ -n "$(drush st --fields=bootstrap)" ]'
+
+  - name: Update localizations
+    type: command
+    command: drush locale:check && drush locale:update
+    directory: $WODBY_APP_DOCROOT


### PR DESCRIPTION
Considering the move we're making towards in-theme translation, it'd be nice to have the `locale:update` included in post-deployment script, is already added on multiple major projects of ours