### PR TITLE
Add DS_Store to gitignore by default

### DIFF
--- a/assets/gitignore-additions
+++ b/assets/gitignore-additions
@@ -14,3 +14,7 @@ node_modules/
 /web/sites/development.services.yml
 /docker-runtime/
 
+# macOS
+.DS_Store
+
+


### PR DESCRIPTION
As usual, it always happens to have `.DS_Store` caching files in codebases, would be nice to gitignore it