### PR TITLE
Always replace the default 'wodby.yml'

### DIFF
--- a/assets/gitignore-additions
+++ b/assets/gitignore-additions
@@ -14,3 +14,8 @@ node_modules/
 /web/sites/development.services.yml
 /docker-runtime/
 
+# Ignore the default wodby.yml file.
+#
+# You should remove this if you want to make any changes to it.
+# Also remember to update the "drupal-scaffold.file-mapping" options for this file.
+/wodby.yml

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,7 @@
     "extra": {
         "drupal-scaffold": {
             "file-mapping": {
-                "[project-root]/wodby.yml": {
-                    "mode": "replace",
-                    "path": "assets/wodby.yml",
-                    "overwrite": false
-                },
+                "[project-root]/wodby.yml": "assets/wodby.yml",
                 "[project-root]/.circleci/config.yml": {
                     "mode": "replace",
                     "path": "assets/circleci.config.yml",


### PR DESCRIPTION
We usually don't do any changes to the post-deployment script 'wodby.yml', therefore
i suggest that we actually ignore this file as we do for many others, and always use the
most updated one. That way if we update it in this repo also all sites will get the most
recent version.
This can still easily be overridden on a per-project basis.