### PR TITLE
Add "permission fix" to post-deployment wodby.yml

### DIFF
--- a/assets/wodby.yml
+++ b/assets/wodby.yml
@@ -1,7 +1,18 @@
 # For more info about Post deployment scripts in Wodby see:
 # https://wodby.com/docs/1.0/apps/post-deployment-scripts/
 pipeline:
-  # Automatically handles drush cr, updb, cim, ...
+  # This updates the permissions of typically drupal-generatede files which might cause drush cache-rebuild to fail otherwise.
+  - name: "Fix permission on cached files."
+    type: command
+    command: |
+      sudo files_chmod /mnt/files/public/css/ || true;
+      sudo files_chmod /mnt/files/public/js/ || true ;
+      sudo files_chmod /mnt/files/public/languages/ || true ;
+      sudo files_chmod /mnt/files/public/php/ || true;
+      sudo files_chmod /mnt/files/public/translations/ || true ;
+      sudo files_chmod /mnt/files/public/xmlsitemap/ || true;
+
+# Automatically handles drush cr, updb, cim, ...
   - name: Drush Deploy
     type: command
     command: drush deploy

--- a/assets/wodby.yml
+++ b/assets/wodby.yml
@@ -5,12 +5,12 @@ pipeline:
   - name: "Fix permission on cached files."
     type: command
     command: |
-      sudo files_chmod /mnt/files/public/css/ || true;
+      sudo files_chmod /mnt/files/public/css/ || true ;
       sudo files_chmod /mnt/files/public/js/ || true ;
       sudo files_chmod /mnt/files/public/languages/ || true ;
-      sudo files_chmod /mnt/files/public/php/ || true;
+      sudo files_chmod /mnt/files/public/php/ || true ;
       sudo files_chmod /mnt/files/public/translations/ || true ;
-      sudo files_chmod /mnt/files/public/xmlsitemap/ || true;
+      sudo files_chmod /mnt/files/public/xmlsitemap/ || true ;
 
 # Automatically handles drush cr, updb, cim, ...
   - name: Drush Deploy

--- a/assets/wodby.yml
+++ b/assets/wodby.yml
@@ -11,6 +11,8 @@ pipeline:
       sudo files_chmod /mnt/files/public/php/ || true ;
       sudo files_chmod /mnt/files/public/translations/ || true ;
       sudo files_chmod /mnt/files/public/xmlsitemap/ || true ;
+      sudo files_chmod /mnt/files/public/google_tag/ || true ;
+      sudo files_chmod /mnt/files/public/google_analytics/ || true ;
 
 # Automatically handles drush cr, updb, cim, ...
   - name: Drush Deploy


### PR DESCRIPTION
By adding this step we try to prevent errors on the post-deployment action which will leave the site on a unreliable state.

The `drush deploy` action will try to remove the aggregated css/js as part of the cache-rebuild step, because those files are often generated by the php user `www-data` and the post-deploy is handled by the ssh user `wodby` this can lead to permission mismatches and stops the whole post-depoly script. By adding this initial step we mitigate this error while adding minimal overhead.