### PR TITLE
Add "deploy" support for Drush 9 in wodby.yml

### DIFF
--- a/assets/wodby.yml
+++ b/assets/wodby.yml
@@ -2,11 +2,21 @@
 # https://wodby.com/docs/1.0/apps/post-deployment-scripts/
 pipeline:
   # Automatically handles drush cr, updb, cim, ...
-  - name: Drush Deploy
+  - name: "Drush deploy"
     type: command
     command: drush deploy
     directory: $WODBY_APP_ROOT
-    only_if: '[ -n "$(drush st --fields=bootstrap)" ]'
+    only_if: 'drush version --pipe | grep -Eq '^10\.' && [ -n "$(drush st --fields=bootstrap)" ]'
+  # Fallback for drush 9 version.
+  - name: "Drush deploy (v9)"
+    type: command
+    command: |
+      drush updatedb --no-cache-clear -ny && \
+      drush cache:rebuild -ny && \
+      drush config:import -ny && \
+      drush cache:rebuild -ny
+    directory: $WODBY_APP_ROOT
+    only_if: 'drush version --pipe | grep -Eq '^9\.' && [ -n "$(drush st --fields=bootstrap)" ]'
 
   - name: Configure administrator and disable password login for '*@ramsalt.com' accounts.
     type: command


### PR DESCRIPTION
Some sites *cannot* upgrade to drush 10, this makes it not possible to use the default wodby.yml, with this we add a fallback option.

I ma leaving the more streamline `drush deploy` action so we can remove the "drush v9 support" down the line.