### PR TITLE
Invalidate internal page cache bin

### DIFF
--- a/assets/settings.ramsalt.local.php
+++ b/assets/settings.ramsalt.local.php
@@ -21,6 +21,7 @@ $config['system.performance']['js']['preprocess'] = FALSE;
 $config['advagg.settings']['enabled'] = FALSE;
 
 $settings['cache']['bins']['render'] = 'cache.backend.null';
+$settings['cache']['bins']['page'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
 
 // A default value for non-docker users' private files path.


### PR DESCRIPTION
lack of this fails the twig page internal cache invalidation, it's already been [committed to the core](https://www.drupal.org/project/drupal/issues/2921706) example of `settings.local.php` as well