### PR TITLE
Align default PHP version with current latest release

### DIFF
--- a/assets/circleci.config.yml
+++ b/assets/circleci.config.yml
@@ -11,7 +11,7 @@ parameters:
     default: ''
     type: string
   php_version:
-    default: '8.1'
+    default: '8.2'
     type: string
 
 workflows:

--- a/assets/renovate.json
+++ b/assets/renovate.json
@@ -1,4 +1,9 @@
 {
+  "force": {
+    "constraints": {
+      "php": "~8.2.0"
+    }
+  },
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",


### PR DESCRIPTION
By default we should use latest PHP release when scaffolding a new project:
 - Set major.minor version to use in CircleCI config
 - Set constraint in Renovate to the same