### PR TITLE
Add ramsalt module directory to gitignore

### DIFF
--- a/assets/gitignore-additions
+++ b/assets/gitignore-additions
@@ -1,5 +1,6 @@
 # Ignore Ramsalt media modules
 /web/modules/ramsaltmedia/
+/web/modules/ramsalt/
 
 # Ignore Ramsalt media themes
 /web/themes/ramsaltmedia/


### PR DESCRIPTION
Following the discussion [here](https://github.com/ramsalt/drupal-project/pull/24#issuecomment-1751427848), add ramsalt module directory to gitignore