### PR TITLE
Update gitignore-additions to support drush local configs

### DIFF
--- a/assets/gitignore-additions
+++ b/assets/gitignore-additions
@@ -14,3 +14,4 @@ node_modules/
 /web/sites/*/services.local.yml
 /web/sites/development.services.yml
 /docker-runtime/
+/drush/*.local.yml


### PR DESCRIPTION
There are some scenarios that you'd like to override some drush functionalities locally, we should support the possibility out of the box