### PR TITLE
Disable discovery cache bin locally

### DIFF
--- a/assets/settings.ramsalt.local.php
+++ b/assets/settings.ramsalt.local.php
@@ -23,6 +23,7 @@ $config['advagg.settings']['enabled'] = FALSE;
 $settings['cache']['bins']['render'] = 'cache.backend.null';
 $settings['cache']['bins']['page'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+$settings['cache']['bins']['discovery'] = 'cache.backend.null';
 
 // Enable logging with Monolog to dblog.
 // NB: The module monolog and dblog needs to be enabled for this to work.


### PR DESCRIPTION
While working on SDC components on Radix, I noticed that the components might not get picked up without a cache clear, let's disable the `discovery` cache bin locally out of the box