### PR TITLE
Fix the update_free_access settings

### DIFF
--- a/assets/settings.ramsalt.local.php
+++ b/assets/settings.ramsalt.local.php
@@ -69,7 +69,7 @@ $config['swiftmailer.transport']['transport'] = 'native';
 // }
 
 // Enable update.php access even when not being logged in.
-$update_free_access = TRUE;
+$settings['update_free_access'] = TRUE;
 
 // Set a hash for secure one-time login links, cancel links, form tokens, etc.
 $settings['hash_salt'] = 'some-very-long-random-string-to-be-changed';


### PR DESCRIPTION
Wrong syntax, we need to allow `update.php` to access the `$settings` array