### PR TITLE
Replace Renovate config:base with config:recommended preset

### DIFF
--- a/assets/renovate.json
+++ b/assets/renovate.json
@@ -6,7 +6,7 @@
   },
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":preserveSemverRanges",
     "local>ramsalt/renovate-config:drupal"
   ],


### PR DESCRIPTION
Renovate renamed config:base preset to config:recommended in v36.

See https://docs.renovatebot.com/release-notes-for-major-versions/