### PR TITLE
Filter out backtraces when logging to rsyslog

### DIFF
--- a/assets/monolog.rsyslog.services.yml
+++ b/assets/monolog.rsyslog.services.yml
@@ -5,7 +5,7 @@ parameters:
     'page not found': ['null']
     # Ignore access denied messages.
     'access denied': ['null']
-  monolog.processors: ['message_placeholder', 'current_user', 'request_uri', 'ip', 'referer']
+  monolog.processors: ['message_placeholder', 'current_user', 'request_uri', 'ip', 'referer', 'filter_backtrace']
 
 services:
   monolog.handler.udp:


### PR DESCRIPTION
When backtraces from i.e PHP warnings etc are present in log messages, we frequently see fatal errors caused by memory exhaustion from within monolog.  Resolve this condition by filtering backtraces from log messages.