### PR TITLE
Rebuild caches before drush deploy

### DIFF
--- a/assets/wodby.yml
+++ b/assets/wodby.yml
@@ -12,7 +12,9 @@ pipeline:
   -
     name: "Drush Deploy"
     type: command
-    command: drush deploy
+    command: |
+      drush cr
+      drush deploy
     directory: $WODBY_APP_ROOT
     only_if: '[ -n "$(drush st --fields=bootstrap)" ]'
   -


### PR DESCRIPTION
Quite often, we see problems when running drush deploy in Wodby post deployment tasks due to old caches. Make it so that we rebuild caches before running drush deploy by default.

I.e 
```
10:35:15  INFO [command] only_if: found "only_if" attribute in stage "Drush Deploy"
10:35:15  INFO [command] only_if: Drush Deploy
10:35:16  INFO [Drush Deploy][command] only_if output: 
10:35:16  INFO [Drush Deploy][command] only_if output: In LegacyServiceInstantiator.php line 282:
10:35:16  INFO [Drush Deploy][command] only_if output:                                                                     
10:35:16  INFO [Drush Deploy][command] only_if output:   You have requested a non-existent parameter "easy_email.purger".  
10:35:16  INFO [Drush Deploy][command] only_if output:                                                                     
10:35:16  INFO [Drush Deploy][command] only_if output: 
10:35:16  WARN [command] only_if err: exit status 1
10:35:16  WARN [command] exec: skipped this stage "Drush Deploy", since only_if condition failed
```