### PR TITLE
Update phpstan.neon to exclude node_modules

### DIFF
--- a/assets/phpstan.neon
+++ b/assets/phpstan.neon
@@ -6,6 +6,11 @@ parameters:
     paths:
         - web/modules/custom
         - web/themes/custom
+    # Exclude node_modules directories
+    excludePaths:
+        - */node_modules/*
+        - web/themes/custom/*/node_modules
+        - web/modules/custom/*/node_modules
     # We can ignore current issues using a baseline.
     # You create that by running phpstan with the parameter --generate-baseline
     # and uncomment the following lines.

--- a/assets/phpstan.neon
+++ b/assets/phpstan.neon
@@ -8,9 +8,7 @@ parameters:
         - web/themes/custom
     # Exclude node_modules directories
     excludePaths:
-        - */node_modules/*
-        - web/themes/custom/*/node_modules
-        - web/modules/custom/*/node_modules
+        - **/node_modules/*
     # We can ignore current issues using a baseline.
     # You create that by running phpstan with the parameter --generate-baseline
     # and uncomment the following lines.


### PR DESCRIPTION
By default, rather all themes come with a node_modules directory that causes an error when you run PHPStan, we should define the excludePaths by default.