### PR TITLE
PHPStan: Ignore unmatched ignored errors when using a baseline

### DIFF
--- a/assets/phpstan.neon
+++ b/assets/phpstan.neon
@@ -12,5 +12,6 @@ parameters:
     # We can ignore current issues using a baseline.
     # You create that by running phpstan with the parameter --generate-baseline
     # and uncomment the following lines.
+    # reportUnmatchedIgnoredErrors: false
     # includes:
     # - phpstan-baseline.neon


### PR DESCRIPTION
This is relevant if you have created a baseline and you change/remove a file that had ignored errors.

Without the option you would need to recreate the baseline on "every second commit"