### PR TITLE
Add Ramsalt additions to robots.txt and set crawl-delay for Scrapy

### DIFF
--- a/assets/robots.txt-additions
+++ b/assets/robots.txt-additions
@@ -1,0 +1,9 @@
+######################
+# Ramsalt robots.txt #
+######################
+
+# Block Scrapy user agent
+User-agent: Scrapy
+Crawl-delay: 10
+
+# Please insert other directives above the "Ramsalt robots.txt" section

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,10 @@
                     "append": "assets/gitignore-additions",
                     "force-append": true
                 },
+                "[web-root]/robots.txt": {
+                    "append": "assets/robots.txt-additions",
+                    "force-append": true
+                },
                 "[web-root]/modules/custom/.gitkeep": {
                     "mode": "replace",
                     "path": "assets/.gitkeep",


### PR DESCRIPTION
Can be tested in a repo by:
`composer require ramsalt/drupal-scaffold:dev-feature/robots.txt-additions`
followed by
`cat web/robots.txt`