### PR TITLE
Remove local setting config that is no longer needed

### DIFF
--- a/assets/settings.ramsalt.local.php
+++ b/assets/settings.ramsalt.local.php
@@ -6,14 +6,6 @@ $your_email = 'your_username@ramsalt.com';
 $config['system.performance']['css']['preprocess'] = FALSE;
 $config['system.performance']['js']['preprocess'] = FALSE;
 
-// Disable AdvAgg
-$config['advagg.settings']['enabled'] = FALSE;
-
-$settings['cache']['bins']['render'] = 'cache.backend.null';
-$settings['cache']['bins']['page'] = 'cache.backend.null';
-$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
-$settings['cache']['bins']['discovery'] = 'cache.backend.null';
-
 // Enable logging with Monolog to dblog.
 // NB: The module monolog and dblog needs to be enabled for this to work.
 $settings['container_yamls'][] = 'sites/default/monolog.dblog.services.yml';


### PR DESCRIPTION
-devs can use the Drupal UI to change cache setup
-advagg should not be used anymore

We observed that the cache settings can cause memory errors in some cases. If there are other things to update in the file, let me know so I can fix that along with these changes.